### PR TITLE
Increase Monte Carlo iterations

### DIFF
--- a/src/components/FantasyMatch - Kopie.tsx
+++ b/src/components/FantasyMatch - Kopie.tsx
@@ -80,7 +80,7 @@ export default function FantasyMatch() {
   
 
   function runSimulation() {
-    const simulations = Number(localStorage.getItem("mc")) || 500;
+    const simulations = Number(localStorage.getItem("mc")) || 10000;
     const matrix = Array.from({ length: maxGoals }, () => Array(maxGoals).fill(0));
     const maxRank = 240;
     const rankHome = teamRankings[homeTeam] || maxRank;

--- a/src/components/Parameter.tsx
+++ b/src/components/Parameter.tsx
@@ -4,12 +4,12 @@ import { ResultsContext } from "../contexts/ResultsContext";
 import { saveToFile } from "../utils/saveLoad";
 
 export default function Parameter() {
-  // Parameter-State, initial aus localStorage, default 10/500/50
+  // Parameter-State, initial aus localStorage, default 10/10000/50
   const [drawChance, setDrawChance] = useState(
     () => Number(localStorage.getItem("u")) || 10
   );
   const [monteCarloRuns, setMonteCarloRuns] = useState(
-    () => Number(localStorage.getItem("mc")) || 500
+    () => Number(localStorage.getItem("mc")) || 10000
   );
   const [formVsRanking, setFormVsRanking] = useState(
     () => Number(localStorage.getItem("form")) || 50

--- a/src/components/Qualifiziert - Kopie.tsx
+++ b/src/components/Qualifiziert - Kopie.tsx
@@ -111,7 +111,7 @@ export default function Qualifiziert() {
 
     const groupRanks: Record<string, { team: typeof initialData[0]; avgPunkte: number }[]> = {};
 
-    const monteCarloRuns = Number(localStorage.getItem("mc")) || 500;
+    const monteCarloRuns = Number(localStorage.getItem("mc")) || 10000;
     for (let i = 0; i < monteCarloRuns; i++) {
       const tempPoints: { [code: string]: number } = {};
       initialData.forEach(t => tempPoints[t.code] = 0);

--- a/src/components/Qualifiziert.tsx
+++ b/src/components/Qualifiziert.tsx
@@ -111,7 +111,7 @@ export default function Qualifiziert() {
 
     const groupRanks: Record<string, { team: typeof initialData[0]; avgPunkte: number }[]> = {};
 
-    const monteCarloRuns = Number(localStorage.getItem("mc")) || 500;
+    const monteCarloRuns = Number(localStorage.getItem("mc")) || 10000;
     for (let i = 0; i < monteCarloRuns; i++) {
       const tempPoints: { [code: string]: number } = {};
       initialData.forEach(t => tempPoints[t.code] = 0);

--- a/src/components/Statistik - Kopie.tsx
+++ b/src/components/Statistik - Kopie.tsx
@@ -111,7 +111,7 @@ export default function Statistik() {
 
   function runSimulations() {
     if (spiele.length === 0) return;
-    const monteCarloRuns = Number(localStorage.getItem("mc")) || 500;
+    const monteCarloRuns = Number(localStorage.getItem("mc")) || 10000;
     const tempResults: { [team: string]: number[] } = {};
     const tempAllPoints: { [team: string]: number[] } = {};
     const tempPoints: { [team: string]: number } = {};
@@ -174,7 +174,7 @@ export default function Statistik() {
     };
   }
 
-  const monteCarloRuns = Number(localStorage.getItem("mc")) || 500;
+  const monteCarloRuns = Number(localStorage.getItem("mc")) || 10000;
   const sortedTeams = Object.keys(simulatedPoints).sort((a, b) => (simulatedPoints[b] / monteCarloRuns) - (simulatedPoints[a] / monteCarloRuns));
   const maxPoints = teamCodes.length === 4 ? 18 : 24;
 

--- a/src/components/Statistik ohne ELO.tsx
+++ b/src/components/Statistik ohne ELO.tsx
@@ -118,7 +118,7 @@ export default function Statistik() {
 
   function runSimulations() {
     if (spiele.length === 0) return;
-    const monteCarloRuns = Number(localStorage.getItem("mc")) || 500;
+    const monteCarloRuns = Number(localStorage.getItem("mc")) || 10000;
     const tempResults: { [team: string]: number[] } = {};
     const tempAllPoints: { [team: string]: number[] } = {};
     const tempPoints: { [team: string]: number } = {};
@@ -180,7 +180,7 @@ export default function Statistik() {
     };
   }
 
-  const monteCarloRuns = Number(localStorage.getItem("mc")) || 500;
+  const monteCarloRuns = Number(localStorage.getItem("mc")) || 10000;
   const sortedTeams = Object.keys(simulatedPoints).sort((a, b) => (simulatedPoints[b] / monteCarloRuns) - (simulatedPoints[a] / monteCarloRuns));
   const maxPoints = teamCodes.length === 4 ? 18 : 24;
 

--- a/src/components/Statistik.tsx
+++ b/src/components/Statistik.tsx
@@ -111,7 +111,7 @@ export default function Statistik() {
 
   function runSimulations() {
     if (spiele.length === 0) return;
-    const monteCarloRuns = Number(localStorage.getItem("mc")) || 500;
+    const monteCarloRuns = Number(localStorage.getItem("mc")) || 10000;
     const tempResults: { [team: string]: number[] } = {};
     const tempAllPoints: { [team: string]: number[] } = {};
     const tempPoints: { [team: string]: number } = {};
@@ -174,7 +174,7 @@ export default function Statistik() {
     };
   }
 
-  const monteCarloRuns = Number(localStorage.getItem("mc")) || 500;
+  const monteCarloRuns = Number(localStorage.getItem("mc")) || 10000;
   const sortedTeams = Object.keys(simulatedPoints).sort((a, b) => (simulatedPoints[b] / monteCarloRuns) - (simulatedPoints[a] / monteCarloRuns));
   const maxPoints = teamCodes.length === 4 ? 18 : 24;
 

--- a/src/components/TopMenu.tsx
+++ b/src/components/TopMenu.tsx
@@ -7,7 +7,7 @@ export default function TopMenu({ setCurrent }: { setCurrent: (val: string) => v
 
   const getSettings = () => ({
     drawChance: Number(localStorage.getItem("u") || 10),
-    monteCarloRuns: Number(localStorage.getItem("mc") || 500),
+    monteCarloRuns: Number(localStorage.getItem("mc") || 10000),
     formVsRanking: Number(localStorage.getItem("form") || 50),
   });
 

--- a/src/contexts/ResultsContext.tsx
+++ b/src/contexts/ResultsContext.tsx
@@ -64,7 +64,7 @@ export function ResultsProvider({ children }: { children: ReactNode }) {
     }
     const settings = {
       drawChance: Number(window.localStorage.getItem("u") ?? 10),
-      monteCarloRuns: Number(window.localStorage.getItem("mc") ?? 500),
+      monteCarloRuns: Number(window.localStorage.getItem("mc") ?? 10000),
       formVsRanking: Number(window.localStorage.getItem("form") ?? 50),
     };
     saveToFile({ settings, results }).catch(() => {});


### PR DESCRIPTION
## Summary
- set the default Monte Carlo runs to 10000 instead of 500

## Testing
- `npm run build` *(fails: cannot find react modules)*

------
https://chatgpt.com/codex/tasks/task_e_68474ce952cc832ba547565fa944a24b